### PR TITLE
Adds a simple Ant build script.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,30 @@
+<project name="goblin-hunter" basedir="." default="compile">
+
+    <property name="source.dir" value="${basedir}" />
+    <property name="launcher" value="launcher.py" />
+
+    <target name="clean">
+        <delete>
+            <fileset dir="." includes="**/*.pyc" />
+        </delete>
+    </target>
+
+    <target name="compile" depends="clean">
+        <exec executable="python" failonerror="true">
+            <arg value="-m" />
+            <arg value="compileall" />
+            <arg value="-f" />
+            <arg value="-q" />
+            <arg value="-x" />
+            <arg value="/\.git" />
+            <arg value="${source.dir}" />
+        </exec>
+    </target>
+
+    <target name="launch" depends="compile">
+        <exec executable="python" spawn="true">
+            <arg value="${launcher}" />
+        </exec>
+    </target>
+
+</project>

--- a/weapons/pistol.py
+++ b/weapons/pistol.py
@@ -9,11 +9,9 @@ class Pistol(Gun):
         self.direction = direction
 
     def pointLeft(self):
-        print("Pointing left!")
         self.direction = -1
 
     def pointRight(self):
-        print("Pointing right!")
         self.direction = 1
 
     def chamber(self, position):


### PR DESCRIPTION
Initially wanted to go with Ant, then remembered Makefile... but then that has
a stupid \t requirement, so I went back to Ant. Ideal? No. I'd rather not depend
on another VM to 'compile' some bytecode for another VM (Ant requires the JVM; Python
runs in it's own VM..).

Also removed some debugging print statements.